### PR TITLE
On GSL errors, return error messages and raise Python exceptions, rather than aborting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ symphonyPy.j_nu_py?
 ```
 
 ###Arguments for Emissivity and Absorptivity Functions
-* Arguments for all emissivity and absorptivity functions in both `C` and `Python` take the same arguments and ouput a double.  The arguments are: 
+* Arguments for all emissivity and absorptivity functions in both `C` and `Python` take nearly the same arguments and output a double.  The only difference is that the C version has an `error_message` parameter for handling evaluation errors. The arguments are: 
 ```
 j_nu(nu, magnetic_field, electron_density, observer_angle, distribution, polarization, 
-     theta_e, power_law_p, gamma_min, gamma_max, gamma_cutoff, kappa, kappa_width)
+     theta_e, power_law_p, gamma_min, gamma_max, gamma_cutoff, kappa, kappa_width,
+	 error_message)
 ```
 Sample values:
 ```

--- a/src/demo.c
+++ b/src/demo.c
@@ -42,6 +42,7 @@ int main(int argc, char *argv[])
   double max_nuratio = 1e6;
   int points_per_pow_10 = 1;
   int max_index = (int) log10(max_nuratio)*points_per_pow_10;
+  char *error_message = NULL;
 
   printf("\nnu/nu_c         j_nu()          j_nu_fit()");
 
@@ -63,7 +64,8 @@ int main(int argc, char *argv[])
                                           paramsM.gamma_max,        
                                           paramsM.gamma_cutoff,      
                                           paramsM.kappa,              
-                                          paramsM.kappa_width        
+                                          paramsM.kappa_width,
+                                          &error_message
                                           ), 
                                  j_nu_fit(paramsM.nu,
                                           paramsM.magnetic_field,
@@ -77,8 +79,8 @@ int main(int argc, char *argv[])
                                           paramsM.gamma_max,       
                                           paramsM.gamma_cutoff,     
                                           paramsM.kappa,             
-                                          paramsM.kappa_width 
-                                          ));
+                                          paramsM.kappa_width
+				          ));
 
   }
   printf("\n");

--- a/src/integrator/integrate.c
+++ b/src/integrator/integrate.c
@@ -239,7 +239,7 @@ double gamma_integral(double min,
                      )
 {
   double nu_c = get_nu_c(*params);
-
+  gsl_error_handler_t *prev_handler = NULL;
   struct parametersGSL paramsGSL;
   paramsGSL.params = *params;
   paramsGSL.n      = n;
@@ -252,7 +252,7 @@ double gamma_integral(double min,
     quitting.*/
   if(params->nu/nu_c >= 1.e6)
   {
-     gsl_set_error_handler_off();
+     prev_handler = gsl_set_error_handler_off();
   }
 
   double result, error;
@@ -274,6 +274,11 @@ double gamma_integral(double min,
 
   gsl_integration_workspace_free (w);
 
+  if(params->nu/nu_c >= 1.e6)
+  {
+     gsl_set_error_handler(prev_handler);
+  }
+
   return result;
 }
 
@@ -292,6 +297,7 @@ double n_integral(double min,
                   struct parameters * params
                  )
 {
+  gsl_error_handler_t *prev_handler = NULL;
   double nu_c = get_nu_c(*params);
 
   /*For some of the small contributions to the gamma integral at high nu
@@ -302,7 +308,7 @@ double n_integral(double min,
     quitting.*/
   if(params->nu/nu_c >= 1.e6)
   {
-  gsl_set_error_handler_off();
+    prev_handler = gsl_set_error_handler_off();
   }
 
   double result, error;
@@ -323,6 +329,11 @@ double n_integral(double min,
                       gauss_kronrod_rule,  w, &result, &error);
 
   gsl_integration_workspace_free (w);
+
+  if(params->nu/nu_c >= 1.e6)
+  {
+    gsl_set_error_handler(prev_handler);
+  }
 
   return result;
 }

--- a/src/params.c
+++ b/src/params.c
@@ -1,4 +1,5 @@
 #include "params.h"
+#include <stddef.h> /* for NULL */
 
 /*setConstParams: sets values of constant parameters used throughout
  *                the calculation, such as pi or the charge of an 
@@ -32,7 +33,7 @@ void setConstParams(struct parameters *params)
   params->EMISSIVITY       = 11;
   /*Default: find n-space peak adaptively */
   params->use_n_peak       = 0;
-
+  params->error_message    = NULL;
 }
 
 /*get_nu_c: takes in values of electron_charge, magnetic_field, mass_electron,

--- a/src/params.h
+++ b/src/params.h
@@ -60,8 +60,9 @@ struct parameters
     numerical differential_of_f */
   double (*analytic_differential)(double gamma, struct parameters *);
 
-
   int stokes_v_switch;
+
+  char *error_message; /* if not NULL, records source of error in current calculation */
 };
 
 struct parametersGSL

--- a/src/symphony.c
+++ b/src/symphony.c
@@ -1,5 +1,36 @@
 #include "symphony.h"
 
+/* GSL error handling. This isn't thread-safe since we have to use a single
+ * global variable to track the current best error message destination.
+ * Fortunately-ish Python isn't either ... */
+
+void
+_symphony_error_trap (char *message)
+{
+    /* This function does nothing, but you can set a breakpoint on it to enter
+     * a debugger when something bad happens in a calculation. */
+}
+
+static char **global_gsl_error_message = NULL;
+
+static void
+_handle_gsl_error (const char *reason, const char *file, int line, int gsl_errno)
+{
+    const size_t buf_size = 4096; /* arbitrary */
+
+    if (global_gsl_error_message == NULL) {
+       fprintf (stderr, "unhandled GSL error: %s (%d; %s:%d)\n", reason,
+                gsl_errno, file, line);
+       return;
+    }
+
+    *global_gsl_error_message = (char *) calloc (buf_size, 1);
+    snprintf (*global_gsl_error_message, buf_size - 1,
+	      "GSL error: %s (%d; %s:%d)", reason, gsl_errno, file, line);
+    _symphony_error_trap (*global_gsl_error_message);
+}
+
+
 /*j_nu: wrapper for the emissivity calculation; takes in values of all
  *      necessary paramters and sets a struct of parameters using the input
  *      values.  It then passes this struct to n_summation(), which begins
@@ -7,14 +38,17 @@
  *
  *@params: nu, magnetic_field, electron_density, observer_angle,
  *         distribution, polarization, theta_e, power_law_p,
- *         gamma_min, gamma_max, gamma_cutoff, kappa, 
+ *         gamma_min, gamma_max, gamma_cutoff, kappa,
  *         kappa_width
- *@returns: n_summation(&params), which takes the struct of 
- *          parameters (now populated with values) and 
- *          performs the integration to evaluate j_nu().
+ *@returns: n_summation(&params), which takes the struct of
+ *          parameters (now populated with values) and
+ *          performs the integration to evaluate j_nu(). If an
+ *          error occurred and error_message is not NULL,
+ *          *error_message will be set to a malloc()ed string
+ *          explaining the error.
  */
-double j_nu(double nu, 
-            double magnetic_field, 
+double j_nu(double nu,
+            double magnetic_field,
             double electron_density,
             double observer_angle,
             int distribution,
@@ -25,9 +59,13 @@ double j_nu(double nu,
             double gamma_max,
             double gamma_cutoff,
             double kappa,
-            double kappa_width
+            double kappa_width,
+            char **error_message
            )
 {
+  gsl_error_handler_t *prev_handler;
+  double retval;
+
 /*fill the struct with values*/
   struct parameters params;
   setConstParams(&params);
@@ -45,9 +83,29 @@ double j_nu(double nu,
   params.gamma_cutoff       = gamma_cutoff;
   params.kappa              = kappa;
   params.kappa_width        = kappa_width;
-  set_distribution_function(&params);
 
-  return n_summation(&params);
+  if (error_message != NULL)
+    *error_message = NULL; /* Initialize the user's error message. */
+
+  global_gsl_error_message = &params.error_message;
+  prev_handler = gsl_set_error_handler (_handle_gsl_error);
+  set_distribution_function(&params);
+  retval = n_summation(&params);
+  gsl_set_error_handler (prev_handler);
+  global_gsl_error_message = NULL;
+
+  /* Success? */
+
+  if (params.error_message == NULL)
+    return retval;
+
+  /* Something went wrong. Give the caller the error message if they
+   * provided us with a place to save it. */
+
+  if (error_message != NULL)
+    *error_message = params.error_message;
+
+  return NAN;
 }
 
 /*alpha_nu: wrapper for the absorptivity calculation; takes in values of all
@@ -57,10 +115,10 @@ double j_nu(double nu,
  *
  *@params: nu, magnetic_field, electron_density, observer_angle,
  *         distribution, polarization, theta_e, power_law_p,
- *         gamma_min, gamma_max, gamma_cutoff, kappa, 
+ *         gamma_min, gamma_max, gamma_cutoff, kappa,
  *         kappa_width
- *@returns: n_summation(&params), which takes the struct of 
- *          parameters (now populated with values) and 
+ *@returns: n_summation(&params), which takes the struct of
+ *          parameters (now populated with values) and
  *          performs the integration to evaluate alpha_nu().
  */
 
@@ -76,9 +134,13 @@ double alpha_nu(double nu,
                 double gamma_max,
                 double gamma_cutoff,
                 double kappa,
-                double kappa_width
+                double kappa_width,
+		char **error_message
                )
 {
+  gsl_error_handler_t *prev_handler;
+  double retval;
+
 /*fill the struct with values*/
   struct parameters params;
   setConstParams(&params);
@@ -96,8 +158,27 @@ double alpha_nu(double nu,
   params.gamma_cutoff       = gamma_cutoff;
   params.kappa              = kappa;
   params.kappa_width        = kappa_width;
+
+  if (error_message != NULL)
+    *error_message = NULL; /* Initialize the user's error message. */
+
+  global_gsl_error_message = &params.error_message;
+  prev_handler = gsl_set_error_handler (_handle_gsl_error);
   set_distribution_function(&params);
+  retval = n_summation(&params);
+  gsl_set_error_handler (prev_handler);
+  global_gsl_error_message = NULL;
 
-  return n_summation(&params);
+  /* Success? */
+
+  if (params.error_message == NULL)
+    return retval;
+
+  /* Something went wrong. Give the caller the error message if they
+   * provided us with a place to save it. */
+
+  if (error_message != NULL)
+    *error_message = params.error_message;
+
+  return NAN;
 }
-

--- a/src/symphony.h
+++ b/src/symphony.h
@@ -18,7 +18,8 @@ double j_nu(double nu,
             double gamma_max,
             double gamma_cutoff,
             double kappa,
-            double kappa_width);
+            double kappa_width,
+            char **error_message);
 double alpha_nu(double nu,
                 double magnetic_field,
                 double electron_density,
@@ -31,5 +32,6 @@ double alpha_nu(double nu,
                 double gamma_max,
                 double gamma_cutoff,
                 double kappa,
-                double kappa_width);
+                double kappa_width,
+                char **error_message);
 #endif /* SYMPHONY_H_ */

--- a/src/symphonyHeaders.pxd
+++ b/src/symphonyHeaders.pxd
@@ -12,7 +12,8 @@ cdef extern from "symphony.h":
                 double gamma_max,
                 double gamma_cutoff,
                 double kappa,
-                double kappa_width)
+                double kappa_width,
+                char **error_message)
 
     double alpha_nu(double nu,
                     double magnetic_field,
@@ -26,7 +27,8 @@ cdef extern from "symphony.h":
                     double gamma_max,
                     double gamma_cutoff,
                     double kappa,
-                    double kappa_width)
+                    double kappa_width,
+                    char **error_message)
 
     double j_nu_fit(double nu,
                     double magnetic_field,

--- a/src/symphonyPy.pyx
+++ b/src/symphonyPy.pyx
@@ -25,10 +25,14 @@ def j_nu_py(double nu,
                                 symphonyPy.STOKES_U,
                                 symphonyPy.STOKES_V"""
 
-  return j_nu(nu, magnetic_field, electron_density,
-              observer_angle, distribution, polarization,
-              theta_e, power_law_p, gamma_min, gamma_max,
-              gamma_cutoff, kappa, kappa_width)
+  cdef char* error_message = NULL
+  result = j_nu(nu, magnetic_field, electron_density,
+                observer_angle, distribution, polarizatiaon,
+                theta_e, power_law_p, gamma_min, gamma_max,
+                gamma_cutoff, kappa, kappa_width, &error_message)
+  if error_message:
+    raise RuntimeError (error_message)
+  return result
 
 def alpha_nu_py(double nu,
                 double magnetic_field,
@@ -55,10 +59,14 @@ def alpha_nu_py(double nu,
                                 symphonyPy.STOKES_U,
                                 symphonyPy.STOKES_V"""
 
-  return alpha_nu(nu, magnetic_field, electron_density,
-              observer_angle, distribution, polarization,
-              theta_e, power_law_p, gamma_min, gamma_max,
-              gamma_cutoff, kappa, kappa_width)
+  cdef char* error_message = NULL
+  result = alpha_nu(nu, magnetic_field, electron_density,
+                    observer_angle, distribution, polarization,
+                    theta_e, power_law_p, gamma_min, gamma_max,
+                    gamma_cutoff, kappa, kappa_width, &error_message)
+  if error_message:
+    raise RuntimeError (error_message)
+  return result
 
 def j_nu_fit_py(double nu,
                 double magnetic_field,

--- a/src/symphonyPy.pyx
+++ b/src/symphonyPy.pyx
@@ -27,7 +27,7 @@ def j_nu_py(double nu,
 
   cdef char* error_message = NULL
   result = j_nu(nu, magnetic_field, electron_density,
-                observer_angle, distribution, polarizatiaon,
+                observer_angle, distribution, polarization,
                 theta_e, power_law_p, gamma_min, gamma_max,
                 gamma_cutoff, kappa, kappa_width, &error_message)
   if error_message:


### PR DESCRIPTION
Hi,

This PR adds a basic error-handling infrastructure to Symphony. The upshot is that if an integration fails, your code is returned an error message, rather than having it abort as per the GSL default. There are three pieces to this.

First, the top-level `j_nu()` and `alpha_nu()` functions now take a new argument, `char **error_message` — a pointer to a string. If something bad happens, that pointer is filled in with an error message: `*error_message = "something bad happened";`. Otherwise, it's just set to NULL.

Second, the Python bindings now use this argument. If an error message is returned, a `RuntimeError` exception is raised using the error message as its text content.

Finally, this PR adds code to override the GSL error handler function during computations. The error handler now saves the error message using the aforementioned mechanism, rather than aborting the process. The error handler is restored to its previous state after the computation is done, as per standard good practices for this kind of thing.

The result is that imperfect parameters give you exceptions rather than total crashes:

```
11:25 2 >>> import symphonyPy
11:25 3 >>> symphonyPy.j_nu_py (1e9, 100, 1e11, 0.1, symphonyPy.POWER_LAW, symphonyPy.STOKES_I, 0.2, -1.5, 10, 100, 100, 0, 0)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-3-88346949aa82> in <module>()
----> 1 symphonyPy.j_nu_py (1e9, 100, 1e11, 0.1, symphonyPy.POWER_LAW, symphonyPy.STOKES_I, 0.2, -1.5, 10, 100, 100, 0, 0)

symphonyPy.pyx in symphonyPy.j_nu_py (/home/peter/sw/symphony/build/symphonyPy.c:975)()

RuntimeError: GSL error: could not integrate function (5; qag.c:261)
```
