### PR TITLE
Add CMake installation rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 
 ###To download and build *symphony*:
  1. Clone *symphony* from github.  Navigate into the *symphony* folder, and note that it contains a folder named "src/"; create a folder named "build" and navigate into it.
- 2. Type "cmake" followed by the location of the "src/" folder.  Altogether, this line should look something like: "cmake /location/to/symphony/src"
+ 2. Type "cmake" followed by the location of the "src/" folder.  Altogether, this line should look something like: "cmake /location/to/symphony/src". You can add the argument `-DCMAKE_INSTALL_PREFIX=/name/of/dir` to set the name of the directory to install to
  3. Type "make"
+ 4. Optionally, run `make install` to install the library and Python module onto your system.
 
 ###To use *symphony*'s `Python` interface:
  1. Navigate to the "build/" folder created in step 1., above.  Open `Python` in the command line or by writing a ".py" file.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,11 +7,12 @@
 # If a different compiler than the one cmake detects is needed, then the
 # recommended way is to do the following:
 #
-# cmake -D CMAKE_C_COMPILER=mpicc -D CMAKE_CXX_COMPILER=mpic++ /location/to/symphony/src 
+# cmake -D CMAKE_C_COMPILER=mpicc -D CMAKE_CXX_COMPILER=mpic++ /location/to/symphony/src
 
 cmake_minimum_required(VERSION 2.8)
 
 project(symphony)
+set(LIBRARY_VERSION 0.1)
 
 # ------------------------------USER OPTIONS----------------------------------#
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -O3 -g")
@@ -35,6 +36,21 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 
 # System libraries
 find_library(MATH_LIBRARIES m REQUIRED)
+find_package(PythonInterp)
+
+# Derive the Python site-packages directory.
+# http://stackoverflow.com/questions/1242904/
+set(_cmd
+  "from distutils.sysconfig import get_python_lib"
+  "print(get_python_lib(plat_specific=True, prefix=''))")
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" "-c" "${_cmd}"
+  OUTPUT_VARIABLE PYTHON_SITE_DIR
+  ERROR_VARIABLE _pyerr
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(_pyerr)
+  message(FATAL_ERROR "Python command failed:\n${_pyerr}")
+endif(_pyerr)
 
 # External packages
 find_package(GSL REQUIRED)
@@ -83,15 +99,39 @@ cython_add_module(symphonyPy symphonyPy.pyx)
 target_link_libraries(symphonyPy symphony
   ${GSL_LIBRARIES} ${CBLAS_LIBRARIES})
 
+set_target_properties(
+  symphony
+  PROPERTIES
+    VERSION ${LIBRARY_VERSION}
+    SOVERSION ${LIBRARY_VERSION}
+    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+    INSTALL_RPATH_USE_LINK_PATH TRUE
+)
+
+install(TARGETS symphony
+  LIBRARY DESTINATION lib)
+
+set_target_properties(
+  symphonyPy
+  PROPERTIES
+    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
+    INSTALL_RPATH_USE_LINK_PATH TRUE
+)
+
+install(TARGETS symphonyPy
+  LIBRARY DESTINATION ${PYTHON_SITE_DIR})
+
 message("")
 message("#################")
 message("# Build options #")
 message("#################")
 message("")
-message("C Compiler       : " ${CMAKE_C_COMPILER})
-message("C_FLAGS          : " ${CMAKE_C_FLAGS})
-message("GSL Libraries    : " ${GSL_LIBRARIES})
-message("CBLAS Libraries  : " ${CBLAS_LIBRARIES})
-message("NumPy dir        : " ${PYTHON_NUMPY_INCLUDE_DIR})
-message("Cython           : " ${CYTHON_EXECUTABLE})
+message("C Compiler          : " ${CMAKE_C_COMPILER})
+message("C_FLAGS             : " ${CMAKE_C_FLAGS})
+message("GSL Libraries       : " ${GSL_LIBRARIES})
+message("CBLAS Libraries     : " ${CBLAS_LIBRARIES})
+message("NumPy dir           : " ${PYTHON_NUMPY_INCLUDE_DIR})
+message("Cython              : " ${CYTHON_EXECUTABLE})
+message("Library install dir : " ${CMAKE_INSTALL_PREFIX})
+message("Python install dir  : " ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITE_DIR})
 message("")


### PR DESCRIPTION
This makes it so you can type `make install` and install the library and
Python module in the usual way.

We do *not* install the C headers, so it's not actually possible to write C
code that links against libsymphony. That should be fixed, and shouldn't be
hard to fix.

I made up a version number of 0.1 for the shared library. Note that there are
specific semantics to shared library versions that must be respected when
making changes. On the other hand, the shared library version number need not
be identical to the overall package version number.