### PR TITLE
Change Symphony's j_V fit to Dexter 2016 fit

### DIFF
--- a/src/maxwell_juettner/maxwell_juettner_fits.c
+++ b/src/maxwell_juettner/maxwell_juettner_fits.c
@@ -67,13 +67,45 @@ double maxwell_juettner_Q(struct parameters * params)
 
 /*maxwell_juettner_V: fitting formula for the emissivity (polarized in Stokes V)
  *                    produced by a Maxwell-Juettner (relativistic thermal) 
- *                    distribution of electrons. (Eq. 29, 31 of [1])
+ *                    distribution of electrons. 
  *
  *@params: struct of parameters params
  *@returns: fit to the emissivity, polarized in Stokes V, for the given 
  *          parameters for a Maxwell-Juettner distribution.
  */
 double maxwell_juettner_V(struct parameters * params)
+{
+  double nu_c = get_nu_c(*params);
+
+  double nu_s = (3./2.)*nu_c*sin(params->observer_angle)*params->theta_e
+                *params->theta_e;
+
+  double X = params->nu/nu_s;
+
+  double prefactor =  2 * (params->electron_density
+		      * pow(params->electron_charge, 2.))
+                      /(params->speed_light * 3 * pow(3, 0.5));
+	
+  double term1 = params->nu / (pow(params->theta_e, 3)*tan(params->observer_angle));
+	
+  double term2 = ((1.8138 * pow(X, -1.)) +( 3.423 * pow(X, -(2./3.))) +
+                 (0.02955 * pow(X, -(1./2.))) +( 2.0377 * pow(X, -(1./3.))))
+                 *exp(-1.8899 * pow(X, 1./3.));
+	
+  double ans = prefactor*term1*term2;
+	
+  return ans;                                                                                           
+  }
+
+/*maxwell_juettner_V: fitting formula for the emissivity (polarized in Stokes V)
+ *                    produced by a Maxwell-Juettner (relativistic thermal) 
+ *                    distribution of electrons. (Eq. 29, 31 of [1])
+ *
+ *@params: struct of parameters params
+ *@returns: fit to the emissivity, polarized in Stokes V, for the given 
+ *          parameters for a Maxwell-Juettner distribution.
+ */
+double retired_maxwell_juettner_V(struct parameters * params)
 {
   double nu_c = get_nu_c(*params);
 

--- a/src/maxwell_juettner/maxwell_juettner_fits.c
+++ b/src/maxwell_juettner/maxwell_juettner_fits.c
@@ -88,8 +88,8 @@ double maxwell_juettner_V(struct parameters * params)
 	
   double term1 = params->nu / (pow(params->theta_e, 3)*tan(params->observer_angle));
 	
-  double term2 = ((1.8138 * pow(X, -1.)) +( 3.423 * pow(X, -(2./3.))) +
-                 (0.02955 * pow(X, -(1./2.))) +( 2.0377 * pow(X, -(1./3.))))
+  double term2 = ((1.81384 * pow(X, -1.)) +( 3.42319 * pow(X, -(2./3.))) +
+                 (0.0292545 * pow(X, -(1./2.))) +( 2.03773 * pow(X, -(1./3.))))
                  *exp(-1.8899 * pow(X, 1./3.));
 	
   double ans = prefactor*term1*term2;


### PR DESCRIPTION
Still needs documentation and notes changes.  The function "maxwell_juettner_V()" has been changed to the j_V fit from Dexter 2016.  I've kept and renamed the former fitting function, "retired_maxwell_juettner_V()".  The new function needs to be tested more thoroughly still.  Returns nan if sin(\theta_observer) = 0.